### PR TITLE
Add Scope to resources

### DIFF
--- a/configs/resources/code.ts
+++ b/configs/resources/code.ts
@@ -140,6 +140,10 @@ export const Code: IResourceSection[] = [
       {
         name: `JiffyScan`,
         url: `https://www.jiffyscan.xyz/`
+      },
+      {
+        name: `Scope`,
+        url: `https://scope.sh/`
       }
     ]
   },


### PR DESCRIPTION
Adds [Scope](https://scope.sh) to the "block explorers" section on the Resources page.

Scope is a block explorer with a first-class 4337 UserOp support.